### PR TITLE
Split driver stack setup into ROS 2 Jazzy and Humble paths

### DIFF
--- a/getting_started/driving/drive_manual.rst
+++ b/getting_started/driving/drive_manual.rst
@@ -5,7 +5,7 @@ Manual Control
 **Equipment Required:**
 	* Fully built RoboRacer  vehicle
 	* Pit/Host computer
-	* Logitech F710 joypad
+	* Logitech F710 joypad, or another supported controller
 
 **Approximate Time Investment:** 30 minutes - ∞ There is no time limit on fun!
 
@@ -20,10 +20,10 @@ Before we can get the car to drive itself, it’s a good idea to test the car to
 We want to minimize the number of accidents so before we begin, let's first inspect our vehicle.
 
 #. Make sure you have the car running off its LIPO battery.
-#. Plug the USB dongle receiver of the **Logitech Joypad** into the **USB hub**.
+#. Plug the USB dongle receiver of the **joypad** into the **USB hub**.
 #. Make sure you have the VESC connected.
 #. Ensure that both your car and laptop are connected to a wireless access point if you need the car connected to the Internet while you drive it. Otherwise, go back and go through :ref:`Configure Jetson and Peripherals <doc_software_setup>`.
-#. Make sure you’ve cloned the ``f1tenth_system`` repository and set up your docker container as explained in the :ref:`previous section <doc_drive_workspace>`.
+#. Make sure you’ve cloned the ``f1tenth_system`` repository and built the workspace as explained in the :ref:`previous section <doc_drive_workspace>`, or set up your container as explained in the :ref:`Docker section <doc_drive_workspace_docker>`.
 #. This section uses the program ``tmux`` (available via apt-get) to let you run multiple terminals over one SSH connection, and multiple terminals inside the container. You can also use the remote desktop if you prefer a GUI.
 
 Finding the Jetson IP Address
@@ -35,11 +35,35 @@ Before you can SSH into the car, you need the Jetson's IP address. Your laptop a
 
 Then connect with ``ssh <username>@<jetson_ip>`` (for example, ``ssh tristan@172.16.61.134``).
 
-2. Driving the Car
+.. note:: If your car has a SICK ethernet LiDAR, do **not** use ``192.168.0.15`` here — that address is on the isolated LiDAR subnet and is not reachable from your laptop. Use the Jetson's WiFi address.
+
+2. Before the Wheels Touch the Ground
+---------------------------------------
+.. warning:: **Keep the car on a stand until teleoperation is verified.** A mis-set speed scale or a reversed axis can send the car into a wall faster than you can release the deadman switch.
+
+Bring up the driver stack following :ref:`Launching the Driver Stack <doc_drive_workspace>`, then open a second terminal and watch the teleop command topic while you work through the checklist:
+
+.. code-block:: bash
+
+    ros2 topic echo /teleop
+
+#. ``/teleop`` publishes **only** while the manual deadman button is held, and stops immediately on release.
+#. Pushing the left stick forward produces a **positive** speed value. If it is negative, flip the sign on the ``drive-speed`` scale in ``joy_teleop.yaml``.
+#. Pushing the right stick right steers the wheels right.
+#. The ``drive-speed`` scale is ``1.0``, not ``5.0``.
+
+Only once all four hold should you move the car to the floor, and then raise the speed scale gradually.
+
+.. note:: Remember to rebuild after changing anything in ``config/``. See the *Rebuild after editing any config or launch file* step of your :ref:`driver stack setup <doc_drive_workspace>`.
+
+3. Driving the Car
 ----------------------
 #. Open a terminal on the **Pit** laptop and SSH into the car from your computer.
-#. Launch teleop following the instructions for Launching and Testing teleop and the LiDAR in either :ref:`driver stack setup <doc_drive_workspace>` or :ref:`driver stack setup inside a docker container <doc_drive_workspace_docker>` depending on your setup.
-#. Hold the LB button (Dead man's switch) on the controller to start controlling the car. Use the left joystick to move the car forward and backward and the right joystick for steering. If you're using Logitech F710, switch the switch at the back of the joystick to D. The mode light in the front of the joystick should **not** be constantly on. If it is, press the mode button once.
+#. Launch teleop following the instructions for launching and testing teleop and the LiDAR in either :ref:`driver stack setup <doc_drive_workspace>` or :ref:`driver stack setup inside a docker container <doc_drive_workspace_docker>` depending on your setup.
+#. Hold the manual deadman button (LB on the Logitech F710) to start controlling the car. Use the left joystick to move the car forward and backward and the right joystick for steering.
+#. If you're using a Logitech F710, switch the switch at the back of the joystick to **D**. The mode light in the front of the joystick should **not** be constantly on. If it is, press the mode button once.
+
+.. note:: On the **8BitDo Ultimate 2C** the deadman is button **6** rather than button 4, which means ``joy_teleop.yaml`` has to be edited before teleop will respond at all. See step 6 of your :ref:`driver stack setup <doc_drive_workspace>` for the full mapping.
 
 .. #. Run the ``run_container.sh`` script in the ``f1tenth_system`` repo to start the Docker container.
 .. #. Inside the bash session inside the container, run ``tmux`` and spawn several new windows by using ``ctrl+b`` then ``c`` multiple times. You can navigate through these windows with ``ctrl+b`` then ``p`` or ``n``. This is one way to add and navigate through windows, you can also check the tmux cheatsheet for creating and navigating panes, and using mouse mode. You can always create more windows if you need. These will come in handy when you need to run more than one node, or launch more than one launch file.
@@ -50,19 +74,53 @@ Then connect with ``ssh <username>@<jetson_ip>`` (for example, ``ssh tristan@172
 Troubleshooting
 ------------------
 
-* During teleop, if the **joystick is not mapped correctly**, you can change the mapping in ``/f1tenth_ws/src/f1tenth_system/f1tenth_stack/config/joy_teleop.yaml`` in the container. To identify the mapping, you can launch the bringup launch, and echo the ``/joy`` topic. Move the joystick axis around, you should change in the echoed message. The index of the changed value in the array when you move a joystick in on direction is the axis id to that joystick direction. After identifying the correct indices, change the yaml to reflect it under ``human_control``.
-* If **nothing happens**, one reason can be that the driver name is listening on the wrong port for the joystick. To double check, you can check ``joy_teleop.yaml`` again for the `device_name` pararmeter. If you're using the Logitech joystick, the name should match with the udev name we've set up before. If you're using another joystick and did not set udev rules, you can check the assigned name by running ``ls /dev/input/*``. It'll usually follow the format ``/dev/input/js*``, for example ``/dev/input/js0``.
-* Note that the **LB button acts as a “dead man’s switch”,** as releasing it will stop the car. This is for safety in case your car gets out of control.
-* You can see a **mapping of all controls** used by the car in the ``joy_teleop.yaml`` file. For example, in the default configuration, axis 1 (left joystick’s vertical axis) is used for throttle, and axis 2 (right joystick’s horizontal axis) is used for steering. These might be different joystick to joystick.
-* **Motor rotation direction negated.** If you're car is driving backwards when commanded driving forward, move to the :ref:`next section <doc_calib_odom>` to see how to reverse it.
+Teleoperation does nothing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Walk the command chain in order. The first silent link is the fault:
+
+.. code-block:: bash
+
+    ros2 topic echo /joy               # gamepad -> ROS
+    ros2 topic echo /teleop            # joy_teleop -> mux (requires the deadman held)
+    ros2 topic echo /ackermann_drive   # mux -> VESC
+
+If ``/joy`` updates but ``/teleop`` stays silent, the **deadman index is wrong** — recheck it against ``/joy``, counting from zero. If both are silent while the gamepad works in ``jstest``, ``joy_node`` has opened a different device.
+
+The joystick is not mapped correctly
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Change the mapping in ``f1tenth_stack/config/joy_teleop.yaml``. To identify the mapping, launch the bringup and echo the ``/joy`` topic. Move a joystick axis around and watch which entry of the array changes — the index of that entry is the axis id for that joystick direction. After identifying the correct indices, change the yaml to reflect it under ``human_control``, and rebuild.
+
+You can see a **mapping of all controls** used by the car in ``joy_teleop.yaml``. In the default configuration, axis 1 (the left joystick's vertical axis) is used for throttle and axis 2 (the right joystick's horizontal axis) for steering. These differ from joystick to joystick.
+
+The gamepad is not detected at all
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Confirm the kernel sees the device before blaming ROS:
+
+.. code-block:: bash
+
+    ls -l /dev/input/          # expect js0 and event* entries
+    sudo apt install -y joystick
+    jstest /dev/input/js0
+
+If ``jstest`` responds but ``/joy`` does not, the problem is ROS-side. If neither responds, check the controller's mode — on the 8BitDo Ultimate 2C, hold **Start + X** for a few seconds to force XInput mode, then replug the dongle. Switch mode in particular does not enumerate cleanly on Linux.
+
+.. warning:: ``jstest`` and ``joy_node`` numbering can disagree, because ``joy`` uses SDL2 while ``jstest`` reads raw joydev. **Always take indices from** ``ros2 topic echo /joy``.
+
+On ROS 2 Humble, if nothing happens at all, one reason can be that the driver is listening on the wrong port for the joystick. Check ``joy_teleop.yaml`` for the ``device_name`` parameter — if you're using the Logitech joypad, the name should match the udev name set up earlier. If you're using another joystick and did not set udev rules, you can check the assigned name by running ``ls /dev/input/*``; it usually follows the format ``/dev/input/js*``.
+
+Other common problems
+^^^^^^^^^^^^^^^^^^^^^^^
+* Note that the **deadman button acts as a "dead man's switch",** as releasing it will stop the car. This is for safety in case your car gets out of control.
+* **Motor rotation direction negated.** If your car is driving backwards when commanded to drive forward, move to the :ref:`next section <doc_calib_odom>` to see how to reverse it.
+* **Steering off-center or reversed.** This is calibration, not gamepad mapping. See ``config/vesc.yaml``: ``steering_angle_to_servo_offset`` (default ``0.5304``) and ``steering_angle_to_servo_gain`` (default ``-1.2135``) are per-vehicle values. ``speed_to_erpm_gain`` (``4614.0``) likewise depends on your motor and gearing.
 * **VESC out of sync errors**: Check that the VESC is connected. If the error persists, make sure you're using the right VESC firmware.
 * **Serial port busy errors**: Your VESC might have just booted up, give it a few seconds and try again.
-* **SerialException errors** and you’re using the 30LX Hokuyo, the errors might be due to a port conflict: make sure you've set up udev rules, as explained in :ref:`this section <udev_rules>`.
+* **SerialException errors** and you're using the 30LX Hokuyo, the errors might be due to a port conflict: make sure you've set up udev rules, as explained in the :ref:`driver stack setup <doc_drive_workspace>`.
 * **urg_node related errors**: Check the ports (e.g. an ip address in ``sensors.yaml`` can only be used by 10LX, not 30LX, and vice-versa for the udev name ``/dev/sensors/hokuyo``).
+* **Configuration edits appear to have no effect**: you did not rebuild. Run ``colcon build --packages-select f1tenth_stack`` and confirm the change landed in ``install/``.
 
 .. Congratulations on building the car, configuring the system, installing the firmware, and driving the car! You've come a long way. Pat yourself on the back and high five your other hand. You can head over to `Learn <https://roboracer.ai/learn.html>`_ and try out some of the labs there.
 
 .. .. image:: img/drive02.gif
 .. 	:align: center
 .. 	:width: 300px
-

--- a/getting_started/firmware/drive_workspace.rst
+++ b/getting_started/firmware/drive_workspace.rst
@@ -1,4 +1,6 @@
 .. _doc_drive_workspace:
+.. _lidar_setup:
+.. _doc_firmware_hokuyo10:
 
 2. RoboRacer Driver Stack Setup
 =================================
@@ -7,247 +9,61 @@
 	* Pit/Host computer OR
 	* External monitor/display, HDMI cable, keyboard, mouse
 
-**Approximate Time Investment:** 1.5 hour
+**Approximate Time Investment:** 1.5 - 2 hours
 
 .. warning:: **Before you proceed**, this section sets up the driver stack **natively** for Jetson Xavier and above running **JetPack 5.0 or newer** (Ubuntu 20.04+) with ROS 2. For JetPack versions below 5.0 and Jetsons before Xavier, go to :ref:`Driver Stack Setup with Docker Containers <doc_drive_workspace_docker>` and follow the instructions there instead.
 
-Overview
-----------
-We use **ROS 2 Humble** for communication and to run the car. You can find a tutorial on ROS 2 `here <https://docs.ros.org/en/humble/Tutorials.html>`_.
+By the end of this section you will have ROS 2 installed, udev rules in place for the sensors, the RoboRacer driver stack built, your LiDAR and joypad configured, and the car brought up for the first time. Everything is done **on the Jetson**, so you'll need to connect to it via SSH from the Pit laptop or plug in the monitor, keyboard, and mouse.
 
-In this section you'll install ROS 2 Humble and its utilities, set up udev rules for the sensors, install and build the F1TENTH driver stack, and configure your LiDAR.
+**The ROS 2 distribution you install is decided by the Ubuntu version your JetPack image is built on** — you do not get to choose the two independently. Find your row in the table below, then follow **only** that page. Each one is a complete, self-contained procedure covering the same seven steps in the same order, so you should never need to switch between them.
 
-Everything in this section is done on the **Jetson NX**, so you'll need to connect to it via SSH from the Pit laptop or plug in the monitor, keyboard, and mouse.
+.. list-table::
+   :header-rows: 1
+   :widths: 18 24 16 42
 
-1. Installing ROS 2 Humble
-----------------------------
-Follow the official ROS 2 Humble installation guide to install ROS 2 from Debian packages:
+   * - JetPack
+     - Ubuntu
+     - ROS 2
+     - Follow this page
+   * - 7.x (L4T R39)
+     - 24.04 "Noble"
+     - **Jazzy**
+     - :ref:`1. Ubuntu 24.04 - ROS 2 Jazzy <doc_drive_workspace_jazzy>`
+   * - 5.x - 6.x
+     - 20.04 / 22.04
+     - **Humble**
+     - :ref:`2. Ubuntu 22.04 - ROS 2 Humble <doc_drive_workspace_humble>`
+   * - before 5.0
+     - 18.04
+     - Foxy
+     - :ref:`3. Driver Stack Setup with Docker Containers <doc_drive_workspace_docker>`
 
-`ROS 2 Humble — Ubuntu (Debian packages) Installation <https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html>`_
-
-When you reach the install step, install the **ROS-Base Install (Bare Bones)** — this provides the communication libraries, message packages, and command-line tools, with **no GUI tools**:
-
-.. code-block:: bash
-
-    sudo apt install ros-humble-ros-base
-
-2. Installing rosdep
-----------------------
-``rosdep`` is the dependency-resolution tool we'll use to install the driver stack's dependencies. Install and initialize it by following the official guide:
-
-`Installing and initializing rosdep <https://docs.ros.org/en/humble/Installation/Alternatives/Ubuntu-Install-Binary.html#installing-and-initializing-rosdep>`_
-
-3. udev Rules Setup
-----------------------
-When you connect the VESC and a USB LiDAR to the Jetson, the operating system will assign them device names of the form ``/dev/ttyACMx``, where ``x`` is a number that depends on the order in which they were plugged in. For example, if you plug in the LiDAR before the VESC, the LiDAR will be assigned ``/dev/ttyACM0`` and the VESC ``/dev/ttyACM1``. This is a problem, as the car's configuration needs to know which device name belongs to which device, and these can change every time you reboot depending on the initialization order.
-
-Fortunately, Linux has a utility named udev that lets us assign each device a "virtual" name based on its vendor and product IDs. We will use udev to assign persistent device names to the LiDAR, VESC, and joypad by creating configuration files ("rules") in the directory ``/etc/udev/rules.d``.
-
-.. tip:: These rule files have to be created **as root** with a text editor. If you don't already have a terminal editor you're comfortable with, install ``nano`` and use it to open and edit each file — it's the easiest option:
-
-    .. code-block:: bash
-
-        sudo apt install nano
-
-    Then open any file below with ``sudo nano <filename>`` (for example ``sudo nano /etc/udev/rules.d/99-vesc.rules``), paste the rule, and save with ``Ctrl+O`` then exit with ``Ctrl+X``.
-
-**Hokuyo LiDAR rule (skip this first rule if you are not using a Hokuyo USB LiDAR — e.g. if you're using an ethernet SICK LiDAR).**
-
-Open ``/etc/udev/rules.d/99-hokuyo.rules`` and copy in the following rule exactly as it appears below, on a single line, then save it:
+Check which one you have with:
 
 .. code-block:: bash
 
-    KERNEL=="ttyACM[0-9]*", ACTION=="add", ATTRS{idVendor}=="15d1", MODE="0666", GROUP="dialout", SYMLINK+="sensors/hokuyo"
+    lsb_release -a
 
-Next, open ``/etc/udev/rules.d/99-vesc.rules`` and copy in the following rule for the VESC:
+.. toctree::
+   :maxdepth: 1
+   :name: Driver Stack Setup
+   :hidden:
 
-.. code-block:: bash
+   drive_workspace_jazzy
+   drive_workspace_humble
 
-    KERNEL=="ttyACM[0-9]*", ACTION=="add", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", MODE="0666", GROUP="dialout", SYMLINK+="sensors/vesc"
+.. note:: **LiDAR support is the same on both pages.** Step 5 of whichever page you follow covers the **USB Hokuyo** (e.g. the 30LX, which needs nothing beyond the udev rule in step 3), the **Hokuyo 10LX over ethernet**, and the **SICK ethernet LiDAR** (e.g. the TiM5xx). The procedure is identical apart from the name of the driver package — ``ros-jazzy-sick-scan-xd`` or ``ros-humble-sick-scan-xd``.
 
-Then open ``/etc/udev/rules.d/99-joypad-f710.rules`` and add this rule for the joypad:
+.. note:: **Why the Jazzy path needs an extra patch.**
 
-.. code-block:: bash
+    The ROS buildfarm only ever produced Jammy (22.04) packages for Humble, and that will not change — Humble reaches end of life in May 2027 without ever targeting Noble. On Ubuntu 24.04 the corresponding distribution is Jazzy.
 
-    KERNEL=="js[0-9]*", ACTION=="add", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c219", SYMLINK+="input/joypad-f710"
+    ``f1tenth_system``, however, has no Jazzy branch. The repository offers ``foxy-devel``, ``humble-devel``, ``melodic`` and ``braking``, and its ``vesc`` and ``ackermann_mux`` submodules stop at ``humble`` and ``master`` respectively. The procedure on the Jazzy page is therefore to **clone** ``humble-devel`` **and patch it**.
 
-.. note:: The Logitech F710 has a **D/X** switch on the back. The rule above uses the DirectInput (**D**) product ID ``c219``. If your joypad enumerates with product ID ``c21f`` instead, it is in XInput (**X**) mode — either flip the switch to **D**, or replace ``c219`` with ``c21f`` in the rule above. Run ``lsusb`` (look for the *Logitech* entry) to confirm which product ID your joypad reports.
+    Every apt dependency the stack needs — ``sick_scan_xd``, ``ackermann_msgs``, ``joy``, ``joy_teleop``, ``rosbridge_suite``, ``serial_driver``, ``asio_cmake_module``, ``diagnostic_updater`` — is already released for Jazzy, so only the source packages need modifying, and only one of those changes is substantive.
 
-Finally, trigger (activate) the rules by running:
+.. tip:: **On Ubuntu 24.04, consider Docker instead.**
 
-.. code-block:: bash
+    If your car needs to interoperate with other RoboRacer machines in your lab, or you plan to use ``f1tenth_gym_ros`` or the ``f1tenth_labs`` packages, those are Humble-targeted as well and you will end up patching each one. Running a ``ros:humble-ros-base`` container on the same Noble host gives you the stock, documented stack and parity with everyone else's cars. The native Jazzy port is the better choice if the vehicle is standalone.
 
-    sudo udevadm control --reload-rules
-    sudo udevadm trigger
-
-Reboot your system, and you should find the new devices by running:
-
-.. code-block:: bash
-
-    ls /dev/sensors
-    ls /dev/input
-
-If you want to add additional devices and don't know their vendor or product IDs, you can use the command:
-
-.. code-block:: bash
-
-    sudo udevadm info --name=<your_device_name> --attribute-walk
-
-making sure to replace ``<your_device_name>`` with the name of your device (e.g. ``ttyACM0`` if that's what the OS assigned it — the Unix utility ``dmesg`` can help you find that). The topmost entry will be the entry for your device; lower entries are for the device's parents.
-
-4. Installing the F1TENTH Driver Stack
-----------------------------------------
-First, source ROS 2 so that ``colcon`` and the other build tools are available (do this in every new terminal, or add it to your ``~/.bashrc``):
-
-.. code-block:: bash
-
-    source /opt/ros/humble/setup.bash
-
-Create a ROS workspace:
-
-.. code-block:: bash
-
-    cd $HOME && mkdir -p f1tenth_ws/src
-
-Clone the F1TENTH stack repo from the ``humble-devel`` branch:
-
-.. code-block:: bash
-
-    cd f1tenth_ws/src
-    git clone --branch humble-devel https://github.com/f1tenth/f1tenth_system.git
-
-Update the git submodules to pull in all the necessary packages:
-
-.. code-block:: bash
-
-    cd f1tenth_system
-    git submodule update --init --recursive --remote
-
-Install the dependencies with ``rosdep``:
-
-.. code-block:: bash
-
-    cd $HOME/f1tenth_ws
-    rosdep update --include-eol --rosdistro=humble
-    rosdep install --include-eol --from-paths src -i -y --rosdistro=humble
-
-Build the workspace:
-
-.. code-block:: bash
-
-    colcon build
-
-.. note:: If you get a CMake error about ``asio_cmake_module`` being missing while building the ``vesc_driver`` package, install it and build again:
-
-    .. code-block:: bash
-
-        sudo apt install ros-humble-asio-cmake-module
-        colcon build
-
-You can find more details on how the drivers are set up in the README of the `f1tenth_system repo <https://github.com/f1tenth/f1tenth_system>`_.
-
-.. _lidar_setup:
-.. _doc_firmware_hokuyo10:
-
-5. Setting Up Your LiDAR
---------------------------
-The driver stack supports different LiDARs. Follow the option that matches your hardware.
-
-Option 1 — Hokuyo LiDAR
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-If you are using a **USB Hokuyo** (e.g. the 30LX), no extra setup is needed — it is referenced through the udev rule you created in the udev Rules Setup section above.
-
-If you have a **Hokuyo 10LX** that connects over **ethernet**, you'll need to configure the ``eth0`` network. From the factory, the 10LX is assigned the IP ``192.168.0.10`` (note that the LiDAR is on subnet 0).
-
-Open **Network Configuration** in the Linux GUI on the Jetson NX. In the IPv4 tab, add a connection so that the ``eth0`` port is assigned:
-
-    * IP address ``192.168.0.15``
-    * Subnet mask ``255.255.255.0``
-    * Gateway ``192.168.0.10``
-
-Name the connection ``Hokuyo``, save it, and close the network configuration GUI. When you plug in the 10LX, make sure the ``Hokuyo`` connection is selected. If everything is configured properly, you should now be able to ping ``192.168.0.10``.
-
-.. image:: img/hokuyo1.gif
-    :align: center
-    :width: 200px
-
-Option 2 — SICK ethernet LiDAR
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-If you are using a SICK ethernet LiDAR (e.g. a SICK TiM), follow these steps.
-
-1. Install the SICK LiDAR driver:
-
-.. code-block:: bash
-
-    sudo apt install ros-humble-sick-scan-xd
-
-2. Configure the Jetson's wired (ethernet) connection so it is on the **same subnet** as the LiDAR. Open the network settings, edit the **Wired** connection's **IPv4** tab, set the method to **Manual**, and add an address:
-
-    * Address: ``192.168.0.15``
-    * Netmask: ``255.255.255.0``
-    * Gateway: leave blank (no gateway is required for a direct connection)
-
-The address just needs to be on the ``192.168.0.x`` subnet and different from the LiDAR's address. Click **Apply**.
-
-.. figure:: img/sick/ipv4_setup.png
-    :align: center
-
-    Setting a static IPv4 address for the wired connection to the SICK LiDAR.
-
-3. Find the LiDAR's IP address. SICK LiDARs ship with a factory IP on the ``192.168.0.x`` subnet. Scan the subnet to discover which address it's using:
-
-.. code-block:: bash
-
-    sudo nmap -sn 192.168.0.0/24
-
-4. Point the launch files at your LiDAR's IP address. Both files are in:
-
-.. code-block:: bash
-
-    /home/nvidia/f1tenth_ws/src/f1tenth_system/f1tenth_stack/launch/
-
-Open ``sick_tim_5xx.launch``, go to **line 22**, and set the ``hostname`` to your LiDAR's IP address:
-
-.. code-block:: xml
-
-    <arg name="hostname" default="X.X.X.X"/>
-
-.. figure:: img/sick/sick_tim_5xx_launch.png
-    :align: center
-
-    Setting the LiDAR IP in ``sick_tim_5xx.launch``.
-
-Then open ``sick_bringup_launch.py``, go to **line 114**, and set the ``arguments`` path so it points at your ``sick_tim_5xx.launch`` file:
-
-.. code-block:: python
-
-    arguments=["/home/nvidia/f1tenth_ws/src/f1tenth_system/f1tenth_stack/launch/sick_tim_5xx.launch"]
-
-.. figure:: img/sick/sick_bringup_launch.png
-    :align: center
-
-    Pointing ``sick_bringup_launch.py`` at the SICK launch file.
-
-.. note:: The exact line numbers (22 and 114) may shift slightly if the files have been updated — look for the ``hostname`` argument in ``sick_tim_5xx.launch`` and the ``arguments=[...]`` entry of the ``sick_node`` in ``sick_bringup_launch.py``.
-
-6. Launching the Driver Stack
--------------------------------
-Once your LiDAR is configured, source the ROS 2 underlay and your workspace's overlay, then launch the bringup:
-
-.. code-block:: bash
-
-    source /opt/ros/humble/setup.bash
-    cd $HOME/f1tenth_ws
-    source install/setup.bash
-    ros2 launch f1tenth_stack bringup_launch.py
-
-Running the bringup launch will start the VESC drivers, the LiDAR drivers, the joystick drivers, and all necessary packages for running the car. To see the LaserScan messages, open a new terminal and run:
-
-.. code-block:: bash
-
-    source /opt/ros/humble/setup.bash
-    cd $HOME/f1tenth_ws
-    source install/setup.bash
-    rviz2
-
-The rviz window should show up. Add a **LaserScan** visualization on the ``/scan`` topic to see your LiDAR data.
+You can find ROS 2 tutorials for `Humble <https://docs.ros.org/en/humble/Tutorials.html>`__ and `Jazzy <https://docs.ros.org/en/jazzy/Tutorials.html>`__ in the official documentation.

--- a/getting_started/firmware/drive_workspace_humble.rst
+++ b/getting_started/firmware/drive_workspace_humble.rst
@@ -1,0 +1,459 @@
+.. _doc_drive_workspace_humble:
+
+2. Ubuntu 22.04 - ROS 2 Humble
+================================
+**Equipment Required:**
+	* Fully built RoboRacer vehicle
+	* Pit/Host computer OR
+	* External monitor/display, HDMI cable, keyboard, mouse
+
+**Approximate Time Investment:** 1.5 hour
+
+.. note:: This page is the complete driver stack procedure for a Jetson running **JetPack 5.x - 6.x, Ubuntu 20.04 or 22.04**. If your car runs Ubuntu 24.04 "Noble", follow :ref:`1. Ubuntu 24.04 - ROS 2 Jazzy <doc_drive_workspace_jazzy>` instead. Check with ``lsb_release -a``.
+
+Everything below runs **on the Jetson**, either over SSH from the Pit laptop or with a monitor, keyboard, and mouse attached directly.
+
+1. Installing ROS 2 Humble
+----------------------------
+Follow the official ROS 2 Humble installation guide to install ROS 2 from Debian packages:
+
+`ROS 2 Humble - Ubuntu (Debian packages) Installation <https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html>`_
+
+When you reach the install step, install the **ROS-Base Install (Bare Bones)** — this provides the communication libraries, message packages, and command-line tools, with **no GUI tools**:
+
+.. code-block:: bash
+
+    sudo apt install ros-humble-ros-base
+
+Substitute ``ros-humble-desktop`` if you want RViz running on the car itself rather than on the Pit laptop.
+
+2. Installing rosdep
+----------------------
+``rosdep`` is the dependency-resolution tool we'll use to install the driver stack's dependencies. Install and initialize it by following the official guide:
+
+`Installing and initializing rosdep <https://docs.ros.org/en/humble/Installation/Alternatives/Ubuntu-Install-Binary.html#installing-and-initializing-rosdep>`_
+
+.. code-block:: bash
+
+    sudo apt install -y python3-rosdep
+    sudo rosdep init      # skip this if it reports that the file already exists
+    rosdep update
+
+3. udev Rules Setup
+----------------------
+When you connect the VESC and a USB LiDAR to the Jetson, the operating system will assign them device names of the form ``/dev/ttyACMx``, where ``x`` is a number that depends on the order in which they were plugged in. For example, if you plug in the LiDAR before the VESC, the LiDAR will be assigned ``/dev/ttyACM0`` and the VESC ``/dev/ttyACM1``. This is a problem, as the car's configuration needs to know which device name belongs to which device, and these can change every time you reboot depending on the initialization order.
+
+Fortunately, Linux has a utility named udev that lets us assign each device a "virtual" name based on its vendor and product IDs. We will use udev to assign persistent device names to the LiDAR, VESC, and joypad by creating configuration files ("rules") in the directory ``/etc/udev/rules.d``.
+
+.. note:: **These rules are not shipped with the stack.** The ``f1tenth_system`` repository contains no ``.rules`` files — you create them by hand, once per car. They live in ``/etc/udev/rules.d/``, outside the workspace, so they survive workspace rebuilds and deletions.
+
+.. tip:: These rule files have to be created **as root** with a text editor. If you don't already have a terminal editor you're comfortable with, install ``nano`` and use it to open and edit each file — it's the easiest option:
+
+    .. code-block:: bash
+
+        sudo apt install nano
+
+    Then open any file below with ``sudo nano <filename>`` (for example ``sudo nano /etc/udev/rules.d/99-vesc.rules``), paste the rule, and save with ``Ctrl+O`` then exit with ``Ctrl+X``.
+
+The Hokuyo rule
+^^^^^^^^^^^^^^^^^
+**Skip this rule if you are not using a Hokuyo USB LiDAR** — for example, if you have an ethernet SICK LiDAR. Otherwise open ``/etc/udev/rules.d/99-hokuyo.rules`` and copy in the following rule, exactly as it appears below and on a single line:
+
+.. code-block:: bash
+
+    KERNEL=="ttyACM[0-9]*", ACTION=="add", ATTRS{idVendor}=="15d1", MODE="0666", GROUP="dialout", SYMLINK+="sensors/hokuyo"
+
+The VESC rule
+^^^^^^^^^^^^^^^
+Open ``/etc/udev/rules.d/99-vesc.rules`` and copy in the following rule for the VESC:
+
+.. code-block:: bash
+
+    KERNEL=="ttyACM[0-9]*", ACTION=="add", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", MODE="0666", GROUP="dialout", SYMLINK+="sensors/vesc"
+
+The joypad rule
+^^^^^^^^^^^^^^^^^
+Open ``/etc/udev/rules.d/99-joypad-f710.rules`` and add this rule for the joypad:
+
+.. code-block:: bash
+
+    KERNEL=="js[0-9]*", ACTION=="add", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c219", SYMLINK+="input/joypad-f710"
+
+.. note:: The Logitech F710 has a **D/X** switch on the back. The rule above uses the DirectInput (**D**) product ID ``c219``. If your joypad enumerates with product ID ``c21f`` instead, it is in XInput (**X**) mode — either flip the switch to **D**, or replace ``c219`` with ``c21f`` in the rule above. Run ``lsusb`` (look for the *Logitech* entry) to confirm which product ID your joypad reports.
+
+Applying the rules
+^^^^^^^^^^^^^^^^^^^^
+Reload the rules, trigger them, and add yourself to the ``dialout`` group so that you can open the serial device:
+
+.. code-block:: bash
+
+    sudo udevadm control --reload-rules
+    sudo udevadm trigger --action=add
+    sudo usermod -aG dialout $USER
+
+.. warning:: ``--action=add`` is required. A bare ``udevadm trigger`` fires a ``change`` event, but the rules above match ``ACTION=="add"`` — so it silently does nothing and the symlink never appears. Physically unplugging and replugging the device has the same effect as ``--action=add``.
+
+Log out and back in (or reboot) for the ``dialout`` group membership to take effect, then verify:
+
+.. code-block:: bash
+
+    lsusb | grep STMicro      # expect 0483:5740 for the VESC
+    ls -l /dev/sensors/       # expect vesc -> ../ttyACM0
+    ls /dev/input             # expect joypad-f710
+    groups | grep dialout
+
+If you want to add additional devices and don't know their vendor or product IDs, you can use the command:
+
+.. code-block:: bash
+
+    sudo udevadm info --name=<your_device_name> --attribute-walk
+
+making sure to replace ``<your_device_name>`` with the name of your device (e.g. ``ttyACM0`` if that's what the OS assigned it — the Unix utility ``dmesg`` can help you find that). The topmost entry will be the entry for your device; lower entries are for the device's parents.
+
+4. Installing the RoboRacer Driver Stack
+------------------------------------------
+First, source ROS 2 so that ``colcon`` and the other build tools are available (do this in every new terminal, or add it to your ``~/.bashrc``):
+
+.. code-block:: bash
+
+    source /opt/ros/humble/setup.bash
+
+Create a ROS workspace:
+
+.. code-block:: bash
+
+    cd $HOME && mkdir -p f1tenth_ws/src
+
+Clone the RoboRacer stack repo from the ``humble-devel`` branch:
+
+.. code-block:: bash
+
+    cd f1tenth_ws/src
+    git clone --branch humble-devel https://github.com/f1tenth/f1tenth_system.git
+
+Update the git submodules to pull in all the necessary packages:
+
+.. code-block:: bash
+
+    cd f1tenth_system
+    git submodule update --init --recursive --remote
+
+Install the dependencies with ``rosdep``:
+
+.. code-block:: bash
+
+    cd $HOME/f1tenth_ws
+    rosdep update --include-eol --rosdistro=humble
+    rosdep install --include-eol --from-paths src -i -y --rosdistro=humble
+
+Build the workspace:
+
+.. code-block:: bash
+
+    colcon build
+    source install/setup.bash
+
+.. note:: If you get a CMake error about ``asio_cmake_module`` being missing while building the ``vesc_driver`` package, install it and build again:
+
+    .. code-block:: bash
+
+        sudo apt install ros-humble-asio-cmake-module
+        colcon build
+
+You can find more details on how the drivers are set up in the README of the `f1tenth_system repo <https://github.com/f1tenth/f1tenth_system>`_.
+
+5. Setting Up Your LiDAR
+--------------------------
+The driver stack supports different LiDARs. Follow the option that matches your hardware.
+
+Option 1 - Hokuyo LiDAR
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+If you are using a **USB Hokuyo** (e.g. the 30LX), no extra setup is needed — it is referenced through the udev rule you created in step 3.
+
+If you have a **Hokuyo 10LX** that connects over **ethernet**, you'll need to configure the ``eth0`` network. From the factory, the 10LX is assigned the IP ``192.168.0.10`` (note that the LiDAR is on subnet 0).
+
+Open **Network Configuration** in the Linux GUI on the Jetson. In the IPv4 tab, add a connection so that the ``eth0`` port is assigned:
+
+    * IP address ``192.168.0.15``
+    * Subnet mask ``255.255.255.0``
+    * Gateway ``192.168.0.10``
+
+Name the connection ``Hokuyo``, save it, and close the network configuration GUI. When you plug in the 10LX, make sure the ``Hokuyo`` connection is selected. If everything is configured properly, you should now be able to ping ``192.168.0.10``.
+
+.. image:: img/hokuyo1.gif
+    :align: center
+    :width: 200px
+
+Option 2 - SICK ethernet LiDAR
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The SICK TiM connects over ethernet on its own isolated subnet. These units ship with a factory IP on the ``192.168.0.x`` subnet — commonly ``192.168.0.1`` — and the Jetson takes a different address on that same subnet, ``192.168.0.15``.
+
+First install the SICK LiDAR driver:
+
+.. code-block:: bash
+
+    sudo apt install ros-humble-sick-scan-xd
+
+Network setup
+"""""""""""""""
+Configure the Jetson's wired connection so that it is on the **same subnet** as the LiDAR. No gateway is needed for a direct point-to-point link.
+
+*Using the desktop GUI:* open the network settings, edit the **Wired** connection's **IPv4** tab, set the method to **Manual**, and add an address:
+
+    * Address: ``192.168.0.15``
+    * Netmask: ``255.255.255.0``
+    * Gateway: leave blank
+
+The address just needs to be on the ``192.168.0.x`` subnet and different from the LiDAR's address. Click **Apply**.
+
+.. figure:: img/sick/ipv4_setup.png
+    :align: center
+
+    Setting a static IPv4 address for the wired connection to the SICK LiDAR.
+
+*Over SSH, with no desktop:* identify the ethernet interface first, then create the connection with ``nmcli``. ``sudo`` is required; without it ``nmcli`` reports *Insufficient privileges*:
+
+.. code-block:: bash
+
+    ip a                      # find your ethernet interface name
+
+    sudo nmcli con add type ethernet ifname eth0 con-name sick \
+         ipv4.method manual ipv4.addresses 192.168.0.15/24
+    sudo nmcli con up sick
+
+Confirming that the LiDAR responds
+""""""""""""""""""""""""""""""""""""
+Check that the LiDAR answers on both of its service ports — ``2111`` is configuration and ``2112`` is scan data:
+
+.. code-block:: bash
+
+    sudo apt install -y nmap
+    sudo nmap -p 2111,2112 192.168.0.1 # expect both open
+
+If the LiDAR is **not** at ``192.168.0.1`` — a unit reconfigured by a previous user, for example — scan the subnet and look for a MAC address that resolves to *Sick AG*:
+
+.. code-block:: bash
+
+    sudo nmap -sn 192.168.0.0/24
+
+Then substitute that address wherever ``192.168.0.1`` appears below.
+
+.. note:: TiM units run no web server, so ``curl http://192.168.0.1`` returning nothing is expected, and is not a sign that anything is wrong.
+
+Pointing the launch files at the device
+"""""""""""""""""""""""""""""""""""""""""
+Two files in ``f1tenth_stack/launch/`` need your LiDAR's address:
+
+.. code-block:: bash
+
+    /home/nvidia/f1tenth_ws/src/f1tenth_system/f1tenth_stack/launch/
+
+Open ``sick_tim_5xx.launch`` and set the ``hostname`` argument to your LiDAR's IP address:
+
+.. code-block:: xml
+
+    <arg name="hostname" default="192.168.0.1"/>
+
+.. figure:: img/sick/sick_tim_5xx_launch.png
+    :align: center
+
+    Setting the LiDAR IP in ``sick_tim_5xx.launch``.
+
+Then open ``sick_bringup_launch.py`` and set the ``arguments`` entry of the ``sick_node`` so that it points at the absolute path of your ``sick_tim_5xx.launch`` file:
+
+.. code-block:: python
+
+    arguments=["/home/nvidia/f1tenth_ws/src/f1tenth_system/f1tenth_stack/launch/sick_tim_5xx.launch"]
+
+.. figure:: img/sick/sick_bringup_launch.png
+    :align: center
+
+    Pointing ``sick_bringup_launch.py`` at the SICK launch file.
+
+Two things are worth knowing about these files:
+
+* ``sick_tim_5xx.launch`` is a **SICK-internal configuration file**, not a ROS 2 launch file. ``sick_generic_caller`` parses it directly, which is why it uses ROS 1 XML syntax. Leave the syntax as it is.
+* It sets ``scanner_type = sick_tim_5xx``, which is correct for TiM5xx units. A different model (TiM7xx, LMS1xx) requires changing this value, or the node will connect successfully and then fail during scan configuration.
+
+Testing the LiDAR on its own
+""""""""""""""""""""""""""""""
+Testing the LiDAR before full bringup isolates any network or model mismatch from the rest of the stack. Rebuild first, so that the edited launch files are copied into ``install/``:
+
+.. code-block:: bash
+
+    cd $HOME/f1tenth_ws && colcon build --packages-select f1tenth_stack
+    source install/setup.bash
+
+    ros2 run sick_scan_xd sick_generic_caller \
+      $HOME/f1tenth_ws/src/f1tenth_system/f1tenth_stack/launch/sick_tim_5xx.launch
+
+Success looks like ``Setup completed, sick_scan_xd is up and running``, followed shortly by ``Software PLL is ready and locked now!``. A handful of dropped packets before the PLL locks is normal.
+
+In a second terminal, source ROS 2 and your workspace, then check the scan topic:
+
+.. code-block:: bash
+
+    source /opt/ros/humble/setup.bash && source $HOME/f1tenth_ws/install/setup.bash
+    ros2 topic hz /scan
+    ros2 topic echo /scan --once
+
+A TiM5xx publishes at **15 Hz** across a 270° field of view (−135° to +135°) at 0.33° angular resolution. Anything else means the wrong ``scanner_type``.
+
+.. tip:: Use ``--once``, not ``| head -5``. Piping into ``head`` closes the pipe, and ``ros2 topic echo`` responds with an alarming ``BrokenPipeError`` traceback that means nothing at all.
+
+6. Configuring the Joypad
+---------------------------
+The joypad mapping lives in ``f1tenth_stack/config/joy_teleop.yaml``. Two settings matter before the first drive: which buttons act as the **deadman switches**, and the **speed scale**.
+
+Logitech F710
+^^^^^^^^^^^^^^^
+The F710 is the reference joypad for RoboRacer, and the values shipped in ``joy_teleop.yaml`` already match it — axis 1 for speed, axis 2 for steering, button 4 (LB) as the manual deadman and button 5 (RB) as the autonomous deadman. No mapping changes are needed.
+
+Make sure the **D/X** switch on the back is set to **D**, and that the mode light on the front is **not** constantly lit. If it is, press the mode button once.
+
+Check that ``device_name`` in ``joy_teleop.yaml`` matches the udev symlink you created in step 3 (``/dev/input/joypad-f710``).
+
+8BitDo Ultimate 2C
+^^^^^^^^^^^^^^^^^^^^
+The 8BitDo Ultimate 2C reports raw indices rather than the standard Xbox-style layout that the stack's defaults assume. The axes happen to land where the stack already expects them, so **only the two deadman buttons need changing**:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 20 40
+
+   * - Control
+     - 8BitDo index
+     - Default in repo (F710)
+   * - Speed (left stick, vertical)
+     - axis **1**
+     - 1 — no change
+   * - Steering (right stick, horizontal)
+     - axis **2**
+     - 2 — no change
+   * - Manual deadman (L)
+     - button **6**
+     - 4 — *must change*
+   * - Autonomous deadman (R)
+     - button **8**
+     - 5 — *must change*
+
+Apply both changes, and drop the speed scale to ``1.0`` for initial testing:
+
+.. code-block:: bash
+
+    cd $HOME/f1tenth_ws/src/f1tenth_system/f1tenth_stack/config
+
+    sed -i 's/deadman_buttons: \[4\]/deadman_buttons: [6]/; \
+            s/deadman_buttons: \[5\]/deadman_buttons: [8]/; \
+            s/scale: 5.0/scale: 1.0/' joy_teleop.yaml
+
+    grep -n "deadman_buttons\|scale" joy_teleop.yaml
+
+Leave the ``default:`` block alone — its scales are ``0.0``, so its indices are irrelevant.
+
+Any other joypad
+^^^^^^^^^^^^^^^^^^
+For any pad not listed above, read the indices off the live topic. In one terminal:
+
+.. code-block:: bash
+
+    ros2 run joy joy_node
+
+And in a second:
+
+.. code-block:: bash
+
+    ros2 topic echo /joy
+
+Push each stick to its extreme and hold each bumper, noting which entry of the array changes. The index of that entry is the axis or button id to put into ``joy_teleop.yaml`` under ``human_control``. ``joy_node`` also prints the controller name on startup — confirm that it opened the device you expect.
+
+.. warning:: **Count from index 0.** The *seventh entry printed* is index 6. Off-by-one here is the single most common error in this procedure. Analog triggers also rest at ``1.0`` when uncompressed — those are L2/R2, not the bumpers.
+
+Rebuild after editing any config or launch file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``f1tenth_stack`` is an ``ament_python`` package, so files in ``config/`` and ``launch/`` are **copied** into ``install/``, not symlinked. Editing the source file alone changes nothing at runtime.
+
+.. code-block:: bash
+
+    cd $HOME/f1tenth_ws && colcon build --packages-select f1tenth_stack
+    source install/setup.bash
+
+    # confirm the edit actually reached the installed copy
+    grep -n "deadman_buttons" \
+      install/f1tenth_stack/share/f1tenth_stack/config/joy_teleop.yaml
+
+7. Launching the Driver Stack
+-------------------------------
+Source the ROS 2 underlay and your workspace's overlay, then launch the bringup. Use ``sick_bringup_launch.py`` if you have a SICK LiDAR and ``bringup_launch.py`` otherwise:
+
+.. code-block:: bash
+
+    source /opt/ros/humble/setup.bash
+    cd $HOME/f1tenth_ws
+    source install/setup.bash
+
+    ros2 launch f1tenth_stack bringup_launch.py        # Hokuyo / default
+    ros2 launch f1tenth_stack sick_bringup_launch.py   # SICK ethernet LiDAR
+
+Running the bringup launch will start the VESC drivers, the LiDAR drivers, the joystick drivers, and all necessary packages for running the car. A healthy startup includes these key lines:
+
+.. code-block:: text
+
+    [vesc_driver_node] Connected to VESC with firmware version 5.2
+    [joy_node] Opened joystick: <your controller>
+    [ackermann_mux] Topic handler 'topics.joystick' subscribed to topic 'teleop'
+
+Verify from a second terminal that the sensors are publishing:
+
+.. code-block:: bash
+
+    source /opt/ros/humble/setup.bash && source $HOME/f1tenth_ws/install/setup.bash
+    ros2 topic list
+    ros2 topic hz /scan
+    ros2 topic echo /vesc/odom --once
+
+Visualization
+^^^^^^^^^^^^^^^
+To see the LaserScan messages, open a new terminal and run RViz — on the Pit laptop if the Jetson only has ``ros-base`` installed:
+
+.. code-block:: bash
+
+    source /opt/ros/humble/setup.bash
+    cd $HOME/f1tenth_ws
+    source install/setup.bash
+    rviz2
+
+The RViz window should show up. Add a **LaserScan** display on the ``/scan`` topic and set **Fixed Frame** to ``laser`` to see your LiDAR data.
+
+Foxglove is a good alternative, particularly over WiFi. On the Jetson:
+
+.. code-block:: bash
+
+    sudo apt install -y ros-humble-foxglove-bridge
+    ros2 launch foxglove_bridge foxglove_bridge_launch.xml
+
+Then connect from the laptop to ``ws://<jetson-wifi-ip>:8765``.
+
+.. warning:: Use the Jetson's **WiFi** address here, not ``192.168.0.15`` — that is the isolated LiDAR subnet. Subscribe only to the topics you are actively viewing; adding the ``/cloud`` pointcloud alongside ``/scan`` will saturate a WiFi link.
+
+With the stack running, head over to :ref:`Manual Control <drive_manualcontrol>` to check the teleop chain and take the car for its first drive.
+
+Troubleshooting
+-----------------
+
+**A VESC port error, or** ``/dev/sensors/vesc`` **is missing.**
+    The udev rule did not fire. Re-run ``sudo udevadm trigger --action=add``, or physically replug the device. *Permission denied* instead means that the ``dialout`` group change requires a logout and login.
+
+**A CMake error about** ``asio_cmake_module`` **while building** ``vesc_driver``.
+    Install ``ros-humble-asio-cmake-module`` and build again.
+
+**Edits to a config or launch file appear to have no effect.**
+    You did not rebuild. Always run ``colcon build --packages-select f1tenth_stack`` after touching anything in ``config/`` or ``launch/``, and confirm the change by inspecting the file under ``install/``.
+
+**The SICK node connects and then fails during scan configuration.**
+    The ``scanner_type`` in ``sick_tim_5xx.launch`` does not match your hardware. It ships set to ``sick_tim_5xx``.
+
+**SSH from the Pit laptop fails.**
+    Check the service and the current address on the Jetson with ``systemctl status ssh``, ``ip a`` and ``ip route``. The WiFi address is DHCP-assigned and will change. There should be **no default route** via the ethernet interface — the LiDAR connection was created without a gateway, so if one appears there it will break outbound connectivity. A DHCP reservation on the lab router is worth setting up if you connect to this car regularly.
+
+Joypad and teleop problems are covered in the :ref:`Manual Control <drive_manualcontrol>` section.

--- a/getting_started/firmware/drive_workspace_jazzy.rst
+++ b/getting_started/firmware/drive_workspace_jazzy.rst
@@ -1,0 +1,470 @@
+.. _doc_drive_workspace_jazzy:
+
+1. Ubuntu 24.04 - ROS 2 Jazzy
+===============================
+**Equipment Required:**
+	* Fully built RoboRacer vehicle
+	* Pit/Host computer OR
+	* External monitor/display, HDMI cable, keyboard, mouse
+
+**Approximate Time Investment:** 1.5 - 2 hours
+
+.. note:: This page is the complete driver stack procedure for a Jetson running **JetPack 7 (L4T R39), Ubuntu 24.04 "Noble"**. If your car runs Ubuntu 20.04 or 22.04, follow :ref:`2. Ubuntu 22.04 - ROS 2 Humble <doc_drive_workspace_humble>` instead. Check with ``lsb_release -a``.
+
+Everything below runs **on the Jetson**, either over SSH from the Pit laptop or with a monitor, keyboard, and mouse attached directly.
+
+.. warning:: ``f1tenth_system`` has no Jazzy branch, so step 4 clones ``humble-devel`` and patches it. See :ref:`Why the Jazzy path needs an extra patch <doc_drive_workspace>` for the background, and consider whether a Humble container suits your car better.
+
+1. Installing ROS 2 Jazzy
+---------------------------
+Noble is not in ROS's default apt sources, so the ROS repository has to be added first. Skipping this produces ``E: Unable to locate package ros-jazzy-ros-base``.
+
+.. code-block:: bash
+
+    sudo apt update && sudo apt install -y curl gnupg software-properties-common
+    sudo add-apt-repository -y universe
+
+    sudo curl -fsSL -o /usr/share/keyrings/ros-archive-keyring.gpg \
+      https://raw.githubusercontent.com/ros/rosdistro/master/ros.key
+
+    echo "deb [arch=arm64 signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] \
+    http://packages.ros.org/ros2/ubuntu noble main" \
+      | sudo tee /etc/apt/sources.list.d/ros2.list
+
+    sudo apt update
+
+.. tip:: Read the ``apt update`` output and check the ``packages.ros.org`` line for errors. A bad signing key surfaces there, not later at install time.
+
+Then install the base distribution and the build tools:
+
+.. code-block:: bash
+
+    sudo apt install -y ros-jazzy-ros-base ros-dev-tools
+    echo "source /opt/ros/jazzy/setup.bash" >> ~/.bashrc
+    source ~/.bashrc
+    ros2 --help
+
+``ros-base`` is the bare-bones installation: communication libraries, message packages, and command-line tools, with no GUI. Substitute ``ros-jazzy-desktop`` if you want RViz running on the car itself rather than on the Pit laptop.
+
+.. note:: The JetPack image already sets a UTF-8 locale, so the ``locale-gen`` step in the official ROS instructions is not needed here.
+
+2. Installing rosdep
+----------------------
+``rosdep`` resolves the driver stack's dependencies to system packages.
+
+.. code-block:: bash
+
+    sudo apt install -y python3-rosdep
+    sudo rosdep init      # skip this if it reports that the file already exists
+    rosdep update
+
+Confirm that ``Add distro "jazzy"`` appears in the output.
+
+.. note:: A ``pkg_resources is deprecated`` warning is cosmetic noise from setuptools on Python 3.12 and can be ignored.
+
+3. udev Rules Setup
+----------------------
+When you connect the VESC to the Jetson, the operating system assigns it a device name of the form ``/dev/ttyACMx``, where ``x`` depends on the order in which devices were plugged in. This can change between reboots, which is a problem because the car's configuration needs to know which device name belongs to which piece of hardware.
+
+udev solves this by assigning a persistent symbolic name based on the device's USB vendor and product IDs, through configuration files ("rules") in ``/etc/udev/rules.d``.
+
+.. note:: **These rules are not shipped with the stack.** The ``f1tenth_system`` repository contains no ``.rules`` files — you create them by hand, once per car. They live in ``/etc/udev/rules.d/``, outside the workspace, so they survive workspace rebuilds and deletions.
+
+.. tip:: These rule files have to be created **as root** with a text editor. If you don't already have a terminal editor you're comfortable with, install ``nano`` and use it to open and edit each file — it's the easiest option:
+
+    .. code-block:: bash
+
+        sudo apt install nano
+
+    Then open any file below with ``sudo nano <filename>`` (for example ``sudo nano /etc/udev/rules.d/99-vesc.rules``), paste the rule, and save with ``Ctrl+O`` then exit with ``Ctrl+X``.
+
+The VESC rule
+^^^^^^^^^^^^^^^
+Open ``/etc/udev/rules.d/99-vesc.rules`` and copy in the following rule, exactly as it appears below and on a single line:
+
+.. code-block:: bash
+
+    KERNEL=="ttyACM[0-9]*", ACTION=="add", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", MODE="0666", GROUP="dialout", SYMLINK+="sensors/vesc"
+
+The Hokuyo rule
+^^^^^^^^^^^^^^^^^
+**Skip this rule if you are not using a Hokuyo USB LiDAR** — for example, if you have an ethernet SICK LiDAR. Otherwise open ``/etc/udev/rules.d/99-hokuyo.rules`` and copy in:
+
+.. code-block:: bash
+
+    KERNEL=="ttyACM[0-9]*", ACTION=="add", ATTRS{idVendor}=="15d1", MODE="0666", GROUP="dialout", SYMLINK+="sensors/hokuyo"
+
+Why the joypad needs no rule
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The older RoboRacer documentation includes a ``99-joypad-f710.rules`` file. **On Jazzy you should skip it.** It is a leftover from the Foxy-era stack, when the ``joy`` node read ``/dev/input/jsX`` directly and needed a stable path.
+
+Jazzy's ``joy`` node uses SDL2 instead. The stack's ``joy_teleop.yaml`` leaves ``device_name`` commented out and uses ``device_id: 0`` — an SDL enumeration index, not a filesystem path. SDL finds the controller regardless of any symlink. This is true for the Logitech F710, the 8BitDo, and any other pad.
+
+Applying the rules
+^^^^^^^^^^^^^^^^^^^^
+Reload the rules, trigger them, and add yourself to the ``dialout`` group so that you can open the serial device:
+
+.. code-block:: bash
+
+    sudo udevadm control --reload-rules
+    sudo udevadm trigger --action=add
+    sudo usermod -aG dialout $USER
+
+.. warning:: ``--action=add`` is required. A bare ``udevadm trigger`` fires a ``change`` event, but the rules above match ``ACTION=="add"`` — so it silently does nothing and the symlink never appears. Physically unplugging and replugging the VESC has the same effect as ``--action=add``.
+
+Log out and back in (or reboot) for the ``dialout`` group membership to take effect, then verify:
+
+.. code-block:: bash
+
+    lsusb | grep STMicro      # expect 0483:5740
+    ls -l /dev/sensors/       # expect vesc -> ../ttyACM0
+    groups | grep dialout
+
+If you want to add additional devices and don't know their vendor or product IDs, you can use:
+
+.. code-block:: bash
+
+    sudo udevadm info --name=<your_device_name> --attribute-walk
+
+replacing ``<your_device_name>`` with the name of your device (e.g. ``ttyACM0`` if that's what the OS assigned it — the Unix utility ``dmesg`` can help you find that). The topmost entry will be the entry for your device; lower entries are for the device's parents.
+
+4. Installing the RoboRacer Driver Stack
+------------------------------------------
+Install the apt dependencies first — all of them are released for Jazzy:
+
+.. code-block:: bash
+
+    sudo apt install -y ros-jazzy-sick-scan-xd ros-jazzy-asio-cmake-module \
+                        ros-jazzy-serial-driver ros-jazzy-ackermann-msgs \
+                        ros-jazzy-joy ros-jazzy-joy-teleop ros-jazzy-rosbridge-suite \
+                        ros-jazzy-diagnostic-updater python3-colcon-common-extensions
+
+Then create the workspace and clone the stack. Note that you still clone ``humble-devel``, because there is no Jazzy branch:
+
+.. code-block:: bash
+
+    mkdir -p ~/f1tenth_ws/src && cd ~/f1tenth_ws/src
+    git clone --branch humble-devel https://github.com/f1tenth/f1tenth_system.git
+    cd f1tenth_system
+    git submodule update --init --recursive --remote
+
+Applying the Jazzy patch
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+This is the one change that genuinely matters. The ``vesc_driver``, ``vesc_ackermann`` and ``ackermann_mux`` packages pin ``CMAKE_CXX_STANDARD 14``, but Jazzy's ``rclcpp``, ``serial_driver`` and ``diagnostic_updater`` all require **C++17**, so the build fails without this change. The same packages also declare ``cmake_minimum_required(VERSION 3.5)``, which CMake 3.28 on Noble deprecates loudly and CMake 4 rejects outright.
+
+.. code-block:: bash
+
+    cd ~/f1tenth_ws/src/f1tenth_system
+    find . -name CMakeLists.txt -exec sed -i \
+      -e 's/cmake_minimum_required(VERSION 3\.5)/cmake_minimum_required(VERSION 3.16)/' \
+      -e 's/set(CMAKE_CXX_STANDARD 14)/set(CMAKE_CXX_STANDARD 17)/' {} +
+
+    grep -rn "CMAKE_CXX_STANDARD\|cmake_minimum_required" --include=CMakeLists.txt .
+
+Every result of that last command should now read ``3.16`` and ``17``.
+
+Building the workspace
+^^^^^^^^^^^^^^^^^^^^^^^^
+.. code-block:: bash
+
+    cd ~/f1tenth_ws
+    rosdep install --from-paths src -i -y --rosdistro jazzy
+    colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
+    source install/setup.bash
+
+Expect 11 packages and a couple of minutes on the Jetson.
+
+.. warning:: Do not use ``--symlink-install``. ``f1tenth_stack`` is an ``ament_python`` package with a legacy ``setup.cfg`` that setuptools 68+ on Noble cannot process in editable mode. A plain ``colcon build`` works correctly.
+
+Two messages during the build are expected and harmless:
+
+* ``rosdep install`` may report ``vesc`` or ``ackermann_mux`` as unresolvable keys. They are built from source, not from apt.
+* ``vesc_driver`` and ``vesc_ackermann`` emit a notice about ``ament_auto_package`` header install destinations changing in ROS 2 Kilted. This is forward-compatibility information only.
+
+You can find more details on how the drivers are set up in the README of the `f1tenth_system repo <https://github.com/f1tenth/f1tenth_system>`_.
+
+5. Setting Up Your LiDAR
+--------------------------
+The driver stack supports different LiDARs. Follow the option that matches your hardware.
+
+Option 1 - Hokuyo LiDAR
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+If you are using a **USB Hokuyo** (e.g. the 30LX), no extra setup is needed — it is referenced through the udev rule you created in step 3.
+
+If you have a **Hokuyo 10LX** that connects over **ethernet**, you'll need to configure the ``eth0`` network. From the factory, the 10LX is assigned the IP ``192.168.0.10`` (note that the LiDAR is on subnet 0). Assign the Jetson's wired port:
+
+    * IP address ``192.168.0.15``
+    * Subnet mask ``255.255.255.0``
+    * Gateway ``192.168.0.10``
+
+Name the connection ``Hokuyo`` and save it. When you plug in the 10LX, make sure the ``Hokuyo`` connection is selected. If everything is configured properly, you should now be able to ping ``192.168.0.10``.
+
+.. image:: img/hokuyo1.gif
+    :align: center
+    :width: 200px
+
+Option 2 - SICK ethernet LiDAR
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The SICK TiM connects over ethernet on its own isolated subnet. These units ship with a factory IP on the ``192.168.0.x`` subnet — commonly ``192.168.0.1`` — and the Jetson takes a different address on that same subnet, ``192.168.0.15``. The ``ros-jazzy-sick-scan-xd`` driver was installed in step 4.
+
+Network setup
+"""""""""""""""
+Configure the Jetson's wired connection so that it is on the **same subnet** as the LiDAR. No gateway is needed for a direct point-to-point link.
+
+*Using the desktop GUI:* open the network settings, edit the **Wired** connection's **IPv4** tab, set the method to **Manual**, and add an address:
+
+    * Address: ``192.168.0.15``
+    * Netmask: ``255.255.255.0``
+    * Gateway: leave blank
+
+The address just needs to be on the ``192.168.0.x`` subnet and different from the LiDAR's address. Click **Apply**.
+
+.. figure:: img/sick/ipv4_setup.png
+    :align: center
+
+    Setting a static IPv4 address for the wired connection to the SICK LiDAR.
+
+*Over SSH, with no desktop:* identify the ethernet interface first — on the Jetson Orin this is ``enP8p1s0``. The flags ``UP,LOWER_UP`` confirm that a cable is connected.
+
+.. code-block:: bash
+
+    ip a | grep -A1 "enP"
+
+Then create the connection with ``nmcli``, substituting your own interface name. ``sudo`` is required; without it ``nmcli`` reports *Insufficient privileges*:
+
+.. code-block:: bash
+
+    sudo nmcli con add type ethernet ifname enP8p1s0 con-name sick \
+         ipv4.method manual ipv4.addresses 192.168.0.15/24
+    sudo nmcli con up sick
+
+Confirming that the LiDAR responds
+""""""""""""""""""""""""""""""""""""
+Check the Jetson's address, then check that the LiDAR answers on both of its service ports — ``2111`` is configuration and ``2112`` is scan data:
+
+.. code-block:: bash
+
+    ip a show enP8p1s0 | grep inet     # expect 192.168.0.15/24
+
+    sudo apt install -y nmap
+    sudo nmap -p 2111,2112 192.168.0.1 # expect both open
+
+If the LiDAR is **not** at ``192.168.0.1`` — a unit reconfigured by a previous user, for example — scan the subnet and look for a MAC address that resolves to *Sick AG*:
+
+.. code-block:: bash
+
+    sudo nmap -sn 192.168.0.0/24
+
+Then substitute that address wherever ``192.168.0.1`` appears below.
+
+.. note:: **Two harmless surprises.** ``ping`` may fail with ``socket: Operation not permitted``. That is a missing ``cap_net_raw`` capability on the JetPack ``ping`` binary and is unrelated to the LiDAR — fix it with ``sudo setcap cap_net_raw+p /usr/bin/ping``, or just use ``nmap`` instead. Separately, TiM units run no web server, so ``curl http://192.168.0.1`` returning nothing is expected.
+
+Pointing the launch files at the device
+"""""""""""""""""""""""""""""""""""""""""
+Two files in ``f1tenth_stack/launch/`` need your LiDAR's address.
+
+Open ``sick_tim_5xx.launch`` and set the ``hostname`` argument to your LiDAR's IP address:
+
+.. code-block:: xml
+
+    <arg name="hostname" default="192.168.0.1"/>
+
+.. figure:: img/sick/sick_tim_5xx_launch.png
+    :align: center
+
+    Setting the LiDAR IP in ``sick_tim_5xx.launch``.
+
+Then open ``sick_bringup_launch.py`` and set the ``arguments`` entry of the ``sick_node`` so that it points at the absolute path of your ``sick_tim_5xx.launch`` file:
+
+.. code-block:: python
+
+    arguments=["/home/nvidia/f1tenth_ws/src/f1tenth_system/f1tenth_stack/launch/sick_tim_5xx.launch"]
+
+.. figure:: img/sick/sick_bringup_launch.png
+    :align: center
+
+    Pointing ``sick_bringup_launch.py`` at the SICK launch file.
+
+Two things are worth knowing about these files:
+
+* ``sick_tim_5xx.launch`` is a **SICK-internal configuration file**, not a ROS 2 launch file. ``sick_generic_caller`` parses it directly, which is why it uses ROS 1 XML syntax. Leave the syntax as it is.
+* It sets ``scanner_type = sick_tim_5xx``, which is correct for TiM5xx units. A different model (TiM7xx, LMS1xx) requires changing this value, or the node will connect successfully and then fail during scan configuration.
+
+Testing the LiDAR on its own
+""""""""""""""""""""""""""""""
+Testing the LiDAR before full bringup isolates any network or model mismatch from the rest of the stack. Rebuild first, so that the edited launch files are copied into ``install/``:
+
+.. code-block:: bash
+
+    cd ~/f1tenth_ws && colcon build --packages-select f1tenth_stack
+    source install/setup.bash
+
+    ros2 run sick_scan_xd sick_generic_caller \
+      ~/f1tenth_ws/src/f1tenth_system/f1tenth_stack/launch/sick_tim_5xx.launch
+
+Success looks like ``Setup completed, sick_scan_xd is up and running``, followed shortly by ``Software PLL is ready and locked now!``. A handful of dropped packets before the PLL locks is normal.
+
+In a second terminal, source ROS 2 and your workspace, then check the scan topic:
+
+.. code-block:: bash
+
+    source /opt/ros/jazzy/setup.bash && source ~/f1tenth_ws/install/setup.bash
+    ros2 topic hz /scan
+    ros2 topic echo /scan --once
+
+A TiM5xx publishes at **15 Hz** across a 270° field of view (−135° to +135°) at 0.33° angular resolution. Anything else means the wrong ``scanner_type``.
+
+.. tip:: Use ``--once``, not ``| head -5``. Piping into ``head`` closes the pipe, and ``ros2 topic echo`` responds with an alarming ``BrokenPipeError`` traceback that means nothing at all.
+
+6. Configuring the Joypad
+---------------------------
+The joypad mapping lives in ``f1tenth_stack/config/joy_teleop.yaml``. Two settings matter before the first drive: which buttons act as the **deadman switches**, and the **speed scale**.
+
+Logitech F710
+^^^^^^^^^^^^^^^
+The F710 is the reference joypad for RoboRacer, and the values shipped in ``joy_teleop.yaml`` already match it — axis 1 for speed, axis 2 for steering, button 4 (LB) as the manual deadman and button 5 (RB) as the autonomous deadman. No mapping changes are needed.
+
+Make sure the **D/X** switch on the back is set to **D**, and that the mode light on the front is **not** constantly lit. If it is, press the mode button once.
+
+8BitDo Ultimate 2C
+^^^^^^^^^^^^^^^^^^^^
+SDL2 has no gamepad profile for the 8BitDo Ultimate 2C, so it reports raw indices rather than the standard Xbox-style layout that the stack's defaults assume. The axes happen to land where the stack already expects them, so **only the two deadman buttons need changing**:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 20 40
+
+   * - Control
+     - 8BitDo index
+     - Default in repo (F710)
+   * - Speed (left stick, vertical)
+     - axis **1**
+     - 1 — no change
+   * - Steering (right stick, horizontal)
+     - axis **2**
+     - 2 — no change
+   * - Manual deadman (L)
+     - button **6**
+     - 4 — *must change*
+   * - Autonomous deadman (R)
+     - button **8**
+     - 5 — *must change*
+
+Apply both changes, and drop the speed scale to ``1.0`` for initial testing:
+
+.. code-block:: bash
+
+    cd ~/f1tenth_ws/src/f1tenth_system/f1tenth_stack/config
+
+    sed -i 's/deadman_buttons: \[4\]/deadman_buttons: [6]/; \
+            s/deadman_buttons: \[5\]/deadman_buttons: [8]/; \
+            s/scale: 5.0/scale: 1.0/' joy_teleop.yaml
+
+    grep -n "deadman_buttons\|scale" joy_teleop.yaml
+
+Leave the ``default:`` block alone — its scales are ``0.0``, so its indices are irrelevant.
+
+Any other joypad
+^^^^^^^^^^^^^^^^^^
+For any pad not listed above, read the indices off the live topic. In one terminal:
+
+.. code-block:: bash
+
+    ros2 run joy joy_node
+
+And in a second:
+
+.. code-block:: bash
+
+    ros2 topic echo /joy
+
+Push each stick to its extreme and hold each bumper, noting which entry of the array changes. The index of that entry is the axis or button id to put into ``joy_teleop.yaml`` under ``human_control``. ``joy_node`` also prints the controller name on startup — confirm that it opened the device you expect.
+
+.. warning:: **Count from index 0.** The *seventh entry printed* is index 6. Off-by-one here is the single most common error in this procedure. Analog triggers also rest at ``1.0`` when uncompressed — those are L2/R2, not the bumpers.
+
+Rebuild after editing any config or launch file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``f1tenth_stack`` is an ``ament_python`` package, so files in ``config/`` and ``launch/`` are **copied** into ``install/``, not symlinked. Editing the source file alone changes nothing at runtime.
+
+.. code-block:: bash
+
+    cd ~/f1tenth_ws && colcon build --packages-select f1tenth_stack
+    source install/setup.bash
+
+    # confirm the edit actually reached the installed copy
+    grep -n "deadman_buttons" \
+      install/f1tenth_stack/share/f1tenth_stack/config/joy_teleop.yaml
+
+7. Launching the Driver Stack
+-------------------------------
+Source the ROS 2 underlay and your workspace's overlay, then launch the bringup. Use ``sick_bringup_launch.py`` if you have a SICK LiDAR and ``bringup_launch.py`` otherwise:
+
+.. code-block:: bash
+
+    source /opt/ros/jazzy/setup.bash
+    cd ~/f1tenth_ws && source install/setup.bash
+
+    ros2 launch f1tenth_stack bringup_launch.py        # Hokuyo / default
+    ros2 launch f1tenth_stack sick_bringup_launch.py   # SICK ethernet LiDAR
+
+This starts the VESC drivers, the LiDAR driver, the joystick drivers, the command multiplexer, and the static transform publisher. A healthy startup brings up all eight processes, including these key lines:
+
+.. code-block:: text
+
+    [vesc_driver_node] Connected to VESC with firmware version 5.2
+    [joy_node] Opened joystick: <your controller>
+    [sick_scan_xd] Setup completed, sick_scan_xd is up and running
+    [sick_scan_xd] Software PLL is ready and locked now!
+    [ackermann_mux] Topic handler 'topics.joystick' subscribed to topic 'teleop'
+
+Verify from a second terminal that the sensors are publishing:
+
+.. code-block:: bash
+
+    source /opt/ros/jazzy/setup.bash && source ~/f1tenth_ws/install/setup.bash
+    ros2 topic list
+    ros2 topic hz /scan
+    ros2 topic echo /vesc/odom --once
+
+Visualization
+^^^^^^^^^^^^^^^
+If you installed ``ros-base``, the Jetson has no GUI tools — run RViz on the Pit laptop instead:
+
+.. code-block:: bash
+
+    rviz2
+
+Add a **LaserScan** display on the ``/scan`` topic and set **Fixed Frame** to ``laser`` to see your LiDAR data.
+
+Foxglove is a good alternative, particularly over WiFi. On the Jetson:
+
+.. code-block:: bash
+
+    sudo apt install -y ros-jazzy-foxglove-bridge
+    ros2 launch foxglove_bridge foxglove_bridge_launch.xml
+
+Then connect from the laptop to ``ws://<jetson-wifi-ip>:8765``.
+
+.. warning:: Use the Jetson's **WiFi** address here, not ``192.168.0.15`` — that is the isolated LiDAR subnet. Subscribe only to the topics you are actively viewing; adding the ``/cloud`` pointcloud alongside ``/scan`` will saturate a WiFi link.
+
+With the stack running, head over to :ref:`Manual Control <drive_manualcontrol>` to check the teleop chain and take the car for its first drive.
+
+Troubleshooting
+-----------------
+
+**A VESC port error, or** ``/dev/sensors/vesc`` **is missing.**
+    The udev rule did not fire. Re-run ``sudo udevadm trigger --action=add``, or physically replug the device. *Permission denied* instead means that the ``dialout`` group change requires a logout and login.
+
+**The build fails on** ``vesc_driver``, ``vesc_ackermann`` **or** ``ackermann_mux``.
+    The CMake patch was not applied, or was applied after a previous failed build. Re-run the ``find ... sed`` command, confirm with the ``grep`` that follows it, then ``rm -rf build install log`` and build again.
+
+**Edits to a config or launch file appear to have no effect.**
+    You did not rebuild. Always run ``colcon build --packages-select f1tenth_stack`` after touching anything in ``config/`` or ``launch/``, and confirm the change by inspecting the file under ``install/``.
+
+**The SICK node connects and then fails during scan configuration.**
+    The ``scanner_type`` in ``sick_tim_5xx.launch`` does not match your hardware. It ships set to ``sick_tim_5xx``.
+
+**SSH from the Pit laptop fails.**
+    Check the service and the current address on the Jetson with ``systemctl status ssh``, ``ip a show wlP1p1s0`` and ``ip route``. The WiFi address is DHCP-assigned and will change. There should be **no default route** via the ethernet interface — the LiDAR connection was created without a gateway, so if one appears there it will break outbound connectivity. A DHCP reservation on the lab router is worth setting up if you connect to this car regularly.
+
+Joypad and teleop problems are covered in the :ref:`Manual Control <drive_manualcontrol>` section.

--- a/getting_started/firmware/index.rst
+++ b/getting_started/firmware/index.rst
@@ -4,7 +4,7 @@ Install RoboRacer Driver Stack
 ==============================
 .. note:: This section assumes that you have already completed :ref:`Building the Car <doc_build_car>` and :ref:`System Configuration <doc_software_setup>`.
 
-At the end of this section, you will have the VESC tuned and the lidar connection completed.
+At the end of this section, you will have the VESC tuned, the driver stack built, and the lidar and joypad connections completed.
 
 **Required Equipment:**
 	* Fully built RoboRacer vehicle
@@ -16,10 +16,10 @@ At the end of this section, you will have the VESC tuned and the lidar connectio
 
 With the physical car is built and the system configuration setup, we can start to install the firmware needed on the car.
 
-You will need to :ref:`Configure the VESC <doc_firmware_vesc>` and set up the driver stack. Use the native :ref:`Driver Stack Setup <doc_drive_workspace>` (section 2) **or** the :ref:`Docker Containers <doc_drive_workspace_docker>` version (section 3) depending on your JetPack version — not both. LiDAR setup (Hokuyo or SICK) is covered within the Driver Stack Setup section.
+You will need to :ref:`Configure the VESC <doc_firmware_vesc>` and set up the driver stack. Use the native :ref:`Driver Stack Setup <doc_drive_workspace>` (section 2) **or** the :ref:`Docker Containers <doc_drive_workspace_docker>` version (section 3) depending on your JetPack version — not both. LiDAR setup (Hokuyo or SICK) and joypad configuration are covered within the Driver Stack Setup section.
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
    :name: Firmware Setup
    :hidden:
 
@@ -28,7 +28,7 @@ You will need to :ref:`Configure the VESC <doc_firmware_vesc>` and set up the dr
    drive_workspace_docker
 
 #. :ref:`Configuring the VESC <doc_firmware_vesc>` goes over how to set up and tune the VESC.
-#. :ref:`RoboRacer Driver Stack Setup <doc_drive_workspace>` goes over how to set up the software drivers natively to drive the vehicle with **JetPack 5.0 and above**.
+#. :ref:`RoboRacer Driver Stack Setup <doc_drive_workspace>` goes over how to set up the software drivers natively to drive the vehicle with **JetPack 5.0 and above**. It splits into two self-contained pages — :ref:`Ubuntu 24.04 - ROS 2 Jazzy <doc_drive_workspace_jazzy>` and :ref:`Ubuntu 22.04 - ROS 2 Humble <doc_drive_workspace_humble>` — and you follow only the one matching your JetPack version.
 #. :ref:`RoboRacer Driver Stack Setup with Docker Containers <doc_drive_workspace_docker>` goes over how to set up the software drivers for **JetPack versions before 5.0** using **Docker Containers**.
 
 .. tip::


### PR DESCRIPTION
The driver stack page documents only Ubuntu 22.04 with ROS 2 Humble. Humble has no
Ubuntu 24.04 build and never will — the buildfarm only produces Jammy packages for it,
and it reaches EOL in May 2027 without ever targeting Noble. Jetsons on JetPack 7
(L4T R39, Ubuntu 24.04) therefore need Jazzy, and there is currently nothing in the docs
for them.

Section 2 now splits into two self-contained pages, and the reader follows only the one
matching their JetPack version:

```
2. RoboRacer Driver Stack Setup
   ├── 1. Ubuntu 24.04 - ROS 2 Jazzy     (JetPack 7)
   └── 2. Ubuntu 22.04 - ROS 2 Humble    (JetPack 5-6)
```

Both cover the same seven steps in the same order, so there is no cross-referencing
between them mid-procedure.

## Pages

| File | What it is |
|---|---|
| `drive_workspace.rst` | Reduced to a chooser — a JetPack → Ubuntu → ROS 2 table plus the notes explaining why Jazzy needs a patch and when a Humble container is the better call. Keeps the `doc_drive_workspace`, `lidar_setup` and `doc_firmware_hokuyo10` labels so the existing references from `faq.rst` and the Docker page still resolve. |
| `drive_workspace_jazzy.rst` | **New.** Noble apt repository setup, the CMake patch, and why the F710 udev rule is obsolete under Jazzy. |
| `drive_workspace_humble.rst` | **New**, but content-preserving — the existing Humble procedure, including the F710 udev rule and the D/X product-id note from #80. |

## The one substantive Jazzy difference

`f1tenth_system` has no Jazzy branch — the repo offers `foxy-devel`, `humble-devel`,
`melodic` and `braking`, and the `vesc` / `ackermann_mux` submodules stop at `humble`
and `master`. Every apt dependency the stack needs is already released for Jazzy, so the
documented procedure is to clone `humble-devel` and patch it:

- `vesc_driver`, `vesc_ackermann` and `ackermann_mux` pin `CMAKE_CXX_STANDARD 14`, but
  Jazzy's `rclcpp`, `serial_driver` and `diagnostic_updater` require **C++17**.
- The same packages declare `cmake_minimum_required(VERSION 3.5)`, which CMake 3.28 on
  Noble deprecates loudly and CMake 4 rejects outright.

The page is explicit that a `ros:humble-ros-base` container is the better choice for any
car that has to interoperate with `f1tenth_gym_ros` or `f1tenth_labs`, since those are
Humble-targeted too. The native port is recommended only for a standalone vehicle.

## Fixes that apply to both distributions

- **`udevadm trigger` needs `--action=add`.** A bare `udevadm trigger` fires a `change`
  event while the rules match `ACTION=="add"`, so it silently does nothing and the
  symlink never appears. The old page said `sudo udevadm trigger`, which meant the VESC
  symlink would not show up until an unrelated reboot or replug.
- **SICK LiDAR section expanded** with `nmcli` setup for headless installs, the 2111 /
  2112 service-port check, the `scanner_type` mismatch failure mode (the node connects
  and *then* fails during scan configuration), and a standalone `sick_generic_caller`
  test with the expected 15 Hz / 270° / 0.33° scan so the LiDAR can be isolated from the
  rest of the stack.
- **A joypad section**, which the docs did not previously have: the F710 as the reference
  pad, the 8BitDo Ultimate 2C deadman indices (**6** and **8**, not 4 and 5), how to read
  indices off `/joy` for any other pad, and the mandatory rebuild — `f1tenth_stack` is an
  `ament_python` package, so `config/` and `launch/` are copied into `install/`, not
  symlinked, and editing the source alone changes nothing at runtime.

`drive_manual.rst` gains a pre-drive checklist to run with the car on a stand, and the
`/joy` → `/teleop` → `/ackermann_drive` chain for locating where teleop stops, plus the
note that `jstest` and `joy_node` indices disagree because `joy` uses SDL2 while `jstest`
reads raw joydev.

## Provenance

Everything on the Jazzy page was written while setting up an actual JetPack 7 car — the
CMake patch, the `--action=add` behaviour, the `ping` `cap_net_raw` quirk and the
`--symlink-install` failure are all things that were hit and worked through, not
inferred from release notes.

## Checks

`sphinx-build -W --keep-going -b html` produces **no new warnings** — output is identical
to the current `main` baseline, and every `:ref:` resolves.

One note unrelated to this PR: `main` currently emits 9 `Duplicate explicit target name:
"here"` warnings from `index.rst`, `faq.rst`, `software_host.rst` and `gap_finding.rst`
when built against current docutils. CI last ran green in July, but `requirements.txt` is
unpinned, so the strict build may now fail on `main` for reasons predating this branch.
Happy to fix those in a separate PR — it's `_` → `__` on the affected links.
